### PR TITLE
ability to link against a system-provided zopfli

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
                 'zopfli/src/zopfli/tree.c',
                 'zopfli/src/zopfli/util.c',
                 'zopfli/src/zopfli/zlib_container.c',
+                'zopfli/src/zopfli/zopfli_lib.c',
                 'src/zopflimodule.c',
             ],
         )

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ Python bindings to zopfli
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 from io import open
+import os
 
 
 class custom_build_ext(build_ext):
@@ -28,6 +29,33 @@ class custom_build_ext(build_ext):
 with open("README.rst", "r", encoding="utf-8") as readme:
     long_description = readme.read()
 
+prefer_system_zopfli = bool(os.environ.get('USE_SYSTEM_ZOPFLI'))
+if prefer_system_zopfli:
+    zopfli_ext_kwargs = {
+        'sources': [
+            'src/zopflimodule.c',
+        ],
+        'libraries': ['zopfli'],
+        'define_macros': [('SYSTEM_ZOPFLI', '1')],
+    }
+else:
+    zopfli_ext_kwargs = {
+        'sources': [
+            'zopfli/src/zopfli/blocksplitter.c',
+            'zopfli/src/zopfli/cache.c',
+            'zopfli/src/zopfli/deflate.c',
+            'zopfli/src/zopfli/gzip_container.c',
+            'zopfli/src/zopfli/squeeze.c',
+            'zopfli/src/zopfli/hash.c',
+            'zopfli/src/zopfli/katajainen.c',
+            'zopfli/src/zopfli/lz77.c',
+            'zopfli/src/zopfli/tree.c',
+            'zopfli/src/zopfli/util.c',
+            'zopfli/src/zopfli/zlib_container.c',
+            'zopfli/src/zopfli/zopfli_lib.c',
+            'src/zopflimodule.c',
+        ],
+    }
 
 setup(
     name='zopfli',
@@ -39,23 +67,7 @@ setup(
     description='Zopfli module for python',
     long_description=long_description,
     ext_modules=[
-        Extension('zopfli.zopfli',
-            sources=[
-                'zopfli/src/zopfli/blocksplitter.c',
-                'zopfli/src/zopfli/cache.c',
-                'zopfli/src/zopfli/deflate.c',
-                'zopfli/src/zopfli/gzip_container.c',
-                'zopfli/src/zopfli/squeeze.c',
-                'zopfli/src/zopfli/hash.c',
-                'zopfli/src/zopfli/katajainen.c',
-                'zopfli/src/zopfli/lz77.c',
-                'zopfli/src/zopfli/tree.c',
-                'zopfli/src/zopfli/util.c',
-                'zopfli/src/zopfli/zlib_container.c',
-                'zopfli/src/zopfli/zopfli_lib.c',
-                'src/zopflimodule.c',
-            ],
-        )
+        Extension('zopfli.zopfli', **zopfli_ext_kwargs)
     ],
     package_dir={"": "src"},
     packages=["zopfli"],

--- a/src/zopflimodule.c
+++ b/src/zopflimodule.c
@@ -2,7 +2,13 @@
 #include <Python.h>
 #include <bytesobject.h>
 #include <stdlib.h>
-#include "../zopfli/src/zopfli/zopfli.h"
+
+#ifdef SYSTEM_ZOPFLI
+#define ZOPFLI_H <zopfli.h>
+#else
+#define ZOPFLI_H "../zopfli/src/zopfli/zopfli.h"
+#endif
+#include ZOPFLI_H
 
 #if PY_MAJOR_VERSION >= 3
 #define PyInt_Check PyLong_Check

--- a/src/zopflimodule.c
+++ b/src/zopflimodule.c
@@ -2,9 +2,7 @@
 #include <Python.h>
 #include <bytesobject.h>
 #include <stdlib.h>
-#include "../zopfli/src/zopfli/zlib_container.h"
-#include "../zopfli/src/zopfli/gzip_container.h"
-#include "../zopfli/src/zopfli/util.h"
+#include "../zopfli/src/zopfli/zopfli.h"
 
 #if PY_MAJOR_VERSION >= 3
 #define PyInt_Check PyLong_Check
@@ -43,11 +41,9 @@ zopfli_compress(PyObject *self, PyObject *args, PyObject *keywrds)
   if (keywrds)
     Py_INCREF(keywrds);
   Py_BEGIN_ALLOW_THREADS
-    
-  if (!gzip_mode) 
-    ZopfliZlibCompress(&options, in, insize, &out, &outsize);
-  else 
-    ZopfliGzipCompress(&options, in, insize, &out, &outsize);
+
+  ZopfliFormat output_type = gzip_mode ? ZOPFLI_FORMAT_GZIP : ZOPFLI_FORMAT_ZLIB;
+  ZopfliCompress(&options, output_type, in, insize, &out, &outsize);
   
   Py_END_ALLOW_THREADS
   if (args)


### PR DESCRIPTION
Currently we have a very similar patch in Fedora but adding this would allow Fedora to just use py-zopfli as-is.