### PR TITLE
Modernize CI setup and update Python version support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
 env:
   CIBW_TEST_EXTRAS: test
   CIBW_TEST_COMMAND: pytest {package}/tests -v
+  CIBW_SKIP: "cp38-* cp39-* pp38-*"
 
 jobs:
 
@@ -53,25 +54,11 @@ jobs:
         arch: [auto64]
         build: ["*"]
         include:
-          # the manylinux1 docker images only contain python3.8 and 3.9
-          - os: ubuntu-latest
-            type: manylinux1
-            arch: auto
-            build: "cp{38,39}-*"
-            CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
-            CIBW_MANYLINUX_I686_IMAGE: manylinux1
-          # the manylinux2010 image also contains python 3.10 and pypy3.8
-          - os: ubuntu-latest
-            arch: auto
-            type: manylinux2010
-            build: "pp{38}-* cp310-*"
-            CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
-            CIBW_MANYLINUX_I686_IMAGE: manylinux2010
-          # the manylinux2014 image also contains python 3.11, 3.12, 3.13 and pypy3.9 and 3.10
+          # the manylinux2014 image contains python 3.10, 3.11, 3.12, 3.13, 3.14 and pypy3.9 and 3.10
           - os: ubuntu-latest
             arch: auto
             type: manylinux2014
-            build: "pp39-* pp310-* cp311-* cp312-* cp313-*"
+            build: "pp39-* pp310-* cp310-* cp311-* cp312-* cp313-* cp314-*"
             CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
             CIBW_MANYLINUX_I686_IMAGE: manylinux2014
 
@@ -111,13 +98,13 @@ jobs:
     strategy:
       matrix:
         # aarch64 uses qemu so it's slow, build each py version in parallel jobs
-        python: [38, 39, 310, 311, 312, 313]
+        python: [310, 311, 312, 313, 314]
         arch: [aarch64]
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: docker/setup-qemu-action@v1.2.0
+    - uses: docker/setup-qemu-action@v3
       with:
         platforms: all
     - name: Install dependencies
@@ -144,7 +131,7 @@ jobs:
         path: dist
         merge-multiple: true
 
-    - uses: pypa/gh-action-pypi-publish@v1.4.2
+    - uses: pypa/gh-action-pypi-publish@v1.12.2
       with:
         user: __token__
         password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         path: dist
         merge-multiple: true
 
-    - uses: pypa/gh-action-pypi-publish@v1.12.2
+    - uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
     strategy:
       matrix:
         # aarch64 uses qemu so it's slow, build each py version in parallel jobs
-        python: [310, 311, 312, 313, 314]
+        python: ["cp310", "cp311", "cp312", "cp313", "cp314", "pp311"]
         arch: [aarch64]
     steps:
     - uses: actions/checkout@v4
@@ -114,7 +114,8 @@ jobs:
     - name: Build Wheels
       run: python -m cibuildwheel --output-dir wheelhouse .
       env:
-        CIBW_BUILD: cp${{ matrix.python }}-*
+        CIBW_BUILD: ${{ matrix.python }}-*
+        CIBW_ENABLE: ${{ contains(matrix.python, 'pp') && 'pypy' || '' }}
         CIBW_ARCHS: ${{ matrix.arch }}
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 env:
   CIBW_TEST_EXTRAS: test
   CIBW_TEST_COMMAND: pytest {package}/tests -v
-  CIBW_SKIP: "cp38-* cp39-* pp38-* pp39-* pp310-*"
+  CIBW_SKIP: "cp38-* cp39-* pp38-* pp39-* pp310-* cp314t-*"
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 env:
   CIBW_TEST_EXTRAS: test
   CIBW_TEST_COMMAND: pytest {package}/tests -v
-  CIBW_SKIP: "cp38-* cp39-* pp38-*"
+  CIBW_SKIP: "cp38-* cp39-* pp38-* pp39-*"
 
 jobs:
 
@@ -54,11 +54,11 @@ jobs:
         arch: [auto64]
         build: ["*"]
         include:
-          # the manylinux2014 image contains python 3.10, 3.11, 3.12, 3.13, 3.14 and pypy3.9 and 3.10
+          # the manylinux2014 image contains python 3.10, 3.11, 3.12, 3.13, 3.14 and pypy3.10
           - os: ubuntu-latest
             arch: auto
             type: manylinux2014
-            build: "pp39-* pp310-* cp310-* cp311-* cp312-* cp313-* cp314-*"
+            build: "pp310-* cp310-* cp311-* cp312-* cp313-* cp314-*"
             CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
             CIBW_MANYLINUX_I686_IMAGE: manylinux2014
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 env:
   CIBW_TEST_EXTRAS: test
   CIBW_TEST_COMMAND: pytest {package}/tests -v
-  CIBW_SKIP: "cp38-* cp39-* pp38-* pp39-*"
+  CIBW_SKIP: "cp38-* cp39-* pp38-* pp39-* pp310-*"
 
 jobs:
 
@@ -54,11 +54,12 @@ jobs:
         arch: [auto64]
         build: ["*"]
         include:
-          # the manylinux2014 image contains python 3.10, 3.11, 3.12, 3.13, 3.14 and pypy3.10
+          # the manylinux2014 image contains python 3.10, 3.11, 3.12, 3.13, 3.14 and pypy3.11
           - os: ubuntu-latest
             arch: auto
             type: manylinux2014
-            build: "pp310-* cp310-* cp311-* cp312-* cp313-* cp314-*"
+            build: "pp311-* cp310-* cp311-* cp312-* cp313-* cp314-*"
+            CIBW_ENABLE: pypy
             CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
             CIBW_MANYLINUX_I686_IMAGE: manylinux2014
 
@@ -83,6 +84,7 @@ jobs:
       run: python -m cibuildwheel --output-dir wheelhouse .
       env:
         CIBW_BUILD: ${{ matrix.build }}
+        CIBW_ENABLE: ${{ matrix.CIBW_ENABLE }}
         CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.CIBW_MANYLINUX_I686_IMAGE }}
         CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.CIBW_MANYLINUX_X86_64_IMAGE }}
         CIBW_ARCHS: ${{ matrix.arch }}

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ PYZOPFLI
 cPython bindings for
 `zopfli <http://googledevelopers.blogspot.com/2013/02/compress-data-more-densely-with-zopfli.html>`__.
 
-It requires Python 3.8 or greater.
+It requires Python 3.10 or greater.
 
 USAGE
 =====

--- a/setup.py
+++ b/setup.py
@@ -80,9 +80,14 @@ setup(
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: System :: Archiving :: Compression',
     ],
     url="https://github.com/fonttools/py-zopfli",
@@ -92,5 +97,5 @@ setup(
     },
     setup_requires=["setuptools_scm"],
     extras_require={"test": ["pytest"]},
-    python_requires=">=3.8",
+    python_requires=">=3.10",
 )


### PR DESCRIPTION
- Update GitHub Actions to latest versions
- Add Python 3.14 support
- Drop Python 3.8 and 3.9 support, they are now EOL
