### PR TITLE
Add Python stable ABI support for universal wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 env:
   CIBW_TEST_EXTRAS: test
   CIBW_TEST_COMMAND: pytest {package}/tests -v
-  CIBW_SKIP: "cp38-* cp39-* pp38-* pp39-* pp310-* cp314t-*"
+  CIBW_SKIP: "cp38-* cp39-* cp314t-*"
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ on:
 env:
   CIBW_TEST_EXTRAS: test
   CIBW_TEST_COMMAND: pytest {package}/tests -v
-  CIBW_SKIP: "cp38-* cp39-* cp314t-*"
+  # Skip old Python, free-threaded, and single-arch x86_64 macOS (universal2 covers both archs)
+  CIBW_SKIP: "cp38-* cp39-* cp314t-* cp*-macosx_x86_64"
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,27 +50,29 @@ jobs:
       matrix:
         # macos-13 runners are still x86_64, macos-14 (latest) are arm64; we want to build
         # the x86_64 wheel on/for x86_64 macs
+        # Note: abi3 wheel is built once for cp310 but tested on all versions listed
         os: [macos-13, windows-latest]
         arch: [auto64]
-        build: ["*"]
+        build: ["cp310-* cp311-* cp312-* cp313-* cp314-* pp311-*"]
         CIBW_ENABLE: [pypy]
         include:
-          # the manylinux2014 image contains python 3.10, 3.11, 3.12, 3.13, 3.14 and pypy3.11
+          # manylinux2014: build cp310 abi3 wheel (works on 3.10+) and pypy3.11
+          # abi3 wheel is built once but tested on all cp versions listed
           - os: ubuntu-latest
             arch: auto
             type: manylinux2014
-            build: "pp311-* cp310-* cp311-* cp312-* cp313-* cp314-*"
+            build: "cp310-* cp311-* cp312-* cp313-* cp314-* pp311-*"
             CIBW_ENABLE: pypy
             CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
             CIBW_MANYLINUX_I686_IMAGE: manylinux2014
 
           - os: macos-latest
             arch: universal2
-            build: "*"
+            build: "cp310-* cp311-* cp312-* cp313-* cp314-*"
 
           - os: windows-latest
             arch: auto32
-            build: "*"
+            build: "cp310-* cp311-* cp312-* cp313-* cp314-*"
     steps:
     - uses: actions/checkout@v4
       with:
@@ -96,13 +98,20 @@ jobs:
 
 
   build_arch_wheels:
-    name: py${{ matrix.python }} on ${{ matrix.arch }}
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # aarch64 uses qemu so it's slow, build each py version in parallel jobs
-        python: ["cp310", "cp311", "cp312", "cp313", "cp314", "pp311"]
-        arch: [aarch64]
+        include:
+          # aarch64 CPython: build cp310 abi3 wheel, test on all versions
+          - name: "CPython abi3 on aarch64"
+            build: "cp310-* cp311-* cp312-* cp313-* cp314-*"
+            arch: aarch64
+          # aarch64 PyPy: build and test pp311
+          - name: "PyPy 3.11 on aarch64"
+            build: "pp311-*"
+            arch: aarch64
+            enable: pypy
     steps:
     - uses: actions/checkout@v4
       with:
@@ -115,13 +124,13 @@ jobs:
     - name: Build Wheels
       run: python -m cibuildwheel --output-dir wheelhouse .
       env:
-        CIBW_BUILD: ${{ matrix.python }}-*
-        CIBW_ENABLE: ${{ contains(matrix.python, 'pp') && 'pypy' || '' }}
+        CIBW_BUILD: ${{ matrix.build }}
+        CIBW_ENABLE: ${{ matrix.enable || '' }}
         CIBW_ARCHS: ${{ matrix.arch }}
     - uses: actions/upload-artifact@v4
       with:
         path: wheelhouse/*.whl
-        name: wheels-${{ matrix.arch }}-${{ matrix.python }}
+        name: wheels-${{ matrix.arch }}-${{ matrix.name }}
 
   deploy:
     name: Upload if release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,9 +103,9 @@ jobs:
     strategy:
       matrix:
         include:
-          # aarch64 CPython: build cp310 abi3 wheel, test on all versions
+          # aarch64 CPython: build cp310 abi3 wheel (no need to test on 3.11+ since already tested on x86_64)
           - name: "CPython abi3 on aarch64"
-            build: "cp310-* cp311-* cp312-* cp313-* cp314-*"
+            build: "cp310-*"
             arch: aarch64
           # aarch64 PyPy: build and test pp311
           - name: "PyPy 3.11 on aarch64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,16 @@ requires = [
     "setuptools; platform_python_implementation != 'PyPy'",
 ]
 build-backend = "setuptools.build_meta"
+
+# Run abi3audit after the default repair commands to scan for abi3 violations
+# https://github.com/pypa/abi3audit
+# Only on Unix platforms (Linux/macOS) since Windows has no default repair command
+[[tool.cibuildwheel.overrides]]
+select = "cp*-{linux,macosx}*"
+inherit.repair-wheel-command = "append"
+repair-wheel-command = "pipx run abi3audit --strict --report {wheel}"
+
+# Disable Limited API for PyPy as it doesn't support stable ABI
+[[tool.cibuildwheel.overrides]]
+select = "pp*"
+environment = { USE_PY_LIMITED_API = "0" }

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,14 @@ from io import open
 import os
 
 
+def bool_from_environ(key: str, default: bool = False):
+    """Get a boolean value from an environment variable."""
+    value = os.environ.get(key)
+    if not value:
+        return default
+    return value.lower() not in ("0", "false", "no", "off")
+
+
 class custom_build_ext(build_ext):
     """Pass platform-specific compiler/linker flags"""
 
@@ -29,66 +37,84 @@ class custom_build_ext(build_ext):
 with open("README.rst", "r", encoding="utf-8") as readme:
     long_description = readme.read()
 
-prefer_system_zopfli = bool(os.environ.get('USE_SYSTEM_ZOPFLI'))
+# Python Limited API for stable ABI support is enabled by default.
+# Set USE_PY_LIMITED_API=0 to turn it off.
+# https://docs.python.org/3/c-api/stable.html#limited-c-api
+use_py_limited_api = bool_from_environ("USE_PY_LIMITED_API", default=True)
+# NOTE: this must be kept in sync with python_requires='>=3.10' below
+limited_api_min_version = "0x030a0000"  # Python 3.10
+
+prefer_system_zopfli = bool(os.environ.get("USE_SYSTEM_ZOPFLI"))
+
+# Build list of define_macros
+define_macros = []
+if use_py_limited_api:
+    define_macros.append(("Py_LIMITED_API", limited_api_min_version))
+
 if prefer_system_zopfli:
+    system_define_macros = [("SYSTEM_ZOPFLI", "1")] + define_macros
     zopfli_ext_kwargs = {
-        'sources': [
-            'src/zopflimodule.c',
+        "sources": [
+            "src/zopflimodule.c",
         ],
-        'libraries': ['zopfli', 'zopflipng'],
-        'define_macros': [('SYSTEM_ZOPFLI', '1')],
+        "libraries": ["zopfli", "zopflipng"],
+        "define_macros": system_define_macros,
     }
 else:
     zopfli_ext_kwargs = {
-        'sources': [
-            'zopfli/src/zopfli/blocksplitter.c',
-            'zopfli/src/zopfli/cache.c',
-            'zopfli/src/zopfli/deflate.c',
-            'zopfli/src/zopfli/gzip_container.c',
-            'zopfli/src/zopfli/squeeze.c',
-            'zopfli/src/zopfli/hash.c',
-            'zopfli/src/zopfli/katajainen.c',
-            'zopfli/src/zopfli/lz77.c',
-            'zopfli/src/zopfli/tree.c',
-            'zopfli/src/zopfli/util.c',
-            'zopfli/src/zopfli/zlib_container.c',
-            'zopfli/src/zopfli/zopfli_lib.c',
-            'zopfli/src/zopflipng/lodepng/lodepng.cpp',
-            'zopfli/src/zopflipng/lodepng/lodepng_util.cpp',
-            'zopfli/src/zopflipng/zopflipng_lib.cc',
-            'src/zopflimodule.c',
+        "sources": [
+            "zopfli/src/zopfli/blocksplitter.c",
+            "zopfli/src/zopfli/cache.c",
+            "zopfli/src/zopfli/deflate.c",
+            "zopfli/src/zopfli/gzip_container.c",
+            "zopfli/src/zopfli/squeeze.c",
+            "zopfli/src/zopfli/hash.c",
+            "zopfli/src/zopfli/katajainen.c",
+            "zopfli/src/zopfli/lz77.c",
+            "zopfli/src/zopfli/tree.c",
+            "zopfli/src/zopfli/util.c",
+            "zopfli/src/zopfli/zlib_container.c",
+            "zopfli/src/zopfli/zopfli_lib.c",
+            "zopfli/src/zopflipng/lodepng/lodepng.cpp",
+            "zopfli/src/zopflipng/lodepng/lodepng_util.cpp",
+            "zopfli/src/zopflipng/zopflipng_lib.cc",
+            "src/zopflimodule.c",
         ],
+        "define_macros": define_macros,
     }
 
 setup(
-    name='zopfli',
+    name="zopfli",
     use_scm_version={"write_to": "src/zopfli/_version.py"},
-    author='Adam DePrince',
-    author_email='deprince@googlealumni.com',
-    maintainer='Cosimo Lupo',
-    maintainer_email='cosimo@anthrotype.com',
-    description='Zopfli module for python',
+    author="Adam DePrince",
+    author_email="deprince@googlealumni.com",
+    maintainer="Cosimo Lupo",
+    maintainer_email="cosimo@anthrotype.com",
+    description="Zopfli module for python",
     long_description=long_description,
     ext_modules=[
-        Extension('zopfli.zopfli', **zopfli_ext_kwargs)
+        Extension(
+            "zopfli.zopfli", py_limited_api=use_py_limited_api, **zopfli_ext_kwargs
+        )
     ],
+    options={"bdist_wheel": {"py_limited_api": "cp310"}} if use_py_limited_api else {},
     package_dir={"": "src"},
     packages=["zopfli"],
     zip_safe=True,
-    license='Apache-2.0',
+    license="Apache-2.0",
     include_package_data=True,
     classifiers=[
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12',
-        'Programming Language :: Python :: 3.13',
-        'Programming Language :: Python :: 3.14',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
-        'Topic :: System :: Archiving :: Compression',
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
+        "Topic :: System :: Archiving :: Compression",
     ],
     url="https://github.com/fonttools/py-zopfli",
     test_suite="tests",

--- a/src/zopflimodule.c
+++ b/src/zopflimodule.c
@@ -1,6 +1,5 @@
 #define PY_SSIZE_T_CLEAN size_t
 #include <Python.h>
-#include <bytesobject.h>
 #include <stdlib.h>
 
 #ifdef SYSTEM_ZOPFLI
@@ -77,7 +76,7 @@ is_str(PyObject* v)
     if (PyUnicode_Check(v)) {
         return 1;
     }
-    PyErr_Format(PyExc_TypeError, "expected str, got '%.200s'", Py_TYPE(v)->tp_name);
+    PyErr_SetString(PyExc_TypeError, "expected str");
     return 0;
 }
 

--- a/src/zopflimodule.c
+++ b/src/zopflimodule.c
@@ -76,7 +76,17 @@ is_str(PyObject* v)
     if (PyUnicode_Check(v)) {
         return 1;
     }
-    PyErr_SetString(PyExc_TypeError, "expected str");
+    // Get type name using stable ABI-compatible method
+    PyObject *type_obj = (PyObject *)Py_TYPE(v);
+    PyObject *type_name = PyObject_GetAttrString(type_obj, "__name__");
+    if (type_name && PyUnicode_Check(type_name)) {
+        PyErr_Format(PyExc_TypeError, "expected str, got '%U'", type_name);
+        Py_DECREF(type_name);
+    } else {
+        // Fallback if getting type name fails
+        PyErr_SetString(PyExc_TypeError, "expected str");
+        Py_XDECREF(type_name);
+    }
     return 0;
 }
 


### PR DESCRIPTION
Migrate to Py_LIMITED_API (stable ABI) to build universal wheels that work across Python 3.10+ without rebuilding for each CPython minor version.

We should now get one wheel per platform instead of one per Python version, eliminating the need for annual Python version updates.

This is enabled by default. A `USE_PY_LIMITED_API=0` environment variable can be used at build time (with --no-build-isolation) to disable this and build a version-specific wheel instead.