### PR TITLE
Fix sdist build and add setuptools_scm to build system requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
       with:
         python-version: "3.x"
     - name: Install dependencies
-      run: pip install --upgrade setuptools twine
+      run: pip install --upgrade build twine
     - name: Build sdist
-      run: python setup.py sdist
+      run: python -m build --sdist
     - name: Check metadata
       run: twine check dist/*.tar.gz
     - uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = [
     # pin setuptools on pypy to workaround this bug: https://github.com/pypa/distutils/issues/283
     "setuptools<72.2.0; platform_python_implementation == 'PyPy'",
     "setuptools; platform_python_implementation != 'PyPy'",
+    "setuptools_scm",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
setuptools_scm v10 split its core versioning logic out to the new dependency `vcs-versioning`. The legacy `setup_requires` mechanism in `setup.py` fails to fetch dependencies of fetched eggs, causing the build to crash with `ModuleNotFoundError: No module named 'vcs_versioning'`.

This adds `setuptools_scm` to the `build-system.requires` inside `pyproject.toml`, and updates the CI workflow to build the source distribution using PEP 517 build isolation via the `build` package.