### PR TITLE
Add Windows ARM64 wheel to CI build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,10 @@ jobs:
           - os: windows-latest
             arch: auto32
             build: "cp310-* cp311-* cp312-* cp313-* cp314-*"
+
+          - os: windows-11-arm
+            arch: auto64
+            build: "cp310-* cp311-* cp312-* cp313-* cp314-*"
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Build and test natively on the windows-11-arm runner. Builds cp310 abi3 wheel covering 3.10+, tests on all CPython versions.

Closes #32